### PR TITLE
Fix import order for FolderWatch

### DIFF
--- a/bytehot/src/main/java/org/acmsl/bytehot/domain/FolderWatch.java
+++ b/bytehot/src/main/java/org/acmsl/bytehot/domain/FolderWatch.java
@@ -35,12 +35,12 @@
  */
 package org.acmsl.bytehot.domain;
 
-import java.nio.file.Path;
-
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+
+import java.nio.file.Path;
 
 /**
  * Watches folders for changes, every certain milliseconds.


### PR DESCRIPTION
## Summary
- move Lombok imports ahead of java imports in `FolderWatch`

## Testing
- `mvn test` *(fails: Plugin org.apache.maven.plugins:maven-release-plugin... Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_684db5e105e0832182e0f27abdf6db15